### PR TITLE
Disable certificate check in `HTTPCreditScoreProvider`

### DIFF
--- a/src/LoanBroker/Services/HTTPCreditScoreProvider.cs
+++ b/src/LoanBroker/Services/HTTPCreditScoreProvider.cs
@@ -10,11 +10,18 @@ public class HTTPCreditScoreProvider : ICreditScoreProvider
 
     public async Task<int> Score(Prospect prospect, string requestId)
     {
-        using var httpClient = new HttpClient();
+        using var httpClient = CreateHttpClient();
         var requestRecord = new ScoreRequest(prospect.SSN, requestId);
         var httpResponseMessage = await httpClient.PostAsync(lambdaUrl, JsonContent.Create(requestRecord));
         var scoreResponse = await httpResponseMessage.Content.ReadFromJsonAsync<ScoreResponse>();
         return scoreResponse!.score;
+    }
+
+    HttpClient CreateHttpClient()
+    {
+        var handler = new HttpClientHandler();
+        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+        return new HttpClient(handler);
     }
 }
 


### PR DESCRIPTION
Disable certificate check, certificate states `localhost` causing a mismatch with `core.lambda-url.us-east-1.localhost.localstack.cloud`