### PR TITLE
Suppress https://github.com/advisories/GHSA-38h3-2333-qx47 for OpenTelemetry.Exporter.Jaeger

### DIFF
--- a/src/Bank1Adapter/Bank1Adapter.csproj
+++ b/src/Bank1Adapter/Bank1Adapter.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="..\.dockerignore">
       <Link>.dockerignore</Link>
     </Content>

--- a/src/Bank2Adapter/Bank2Adapter.csproj
+++ b/src/Bank2Adapter/Bank2Adapter.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="..\.dockerignore">
       <Link>.dockerignore</Link>
     </Content>

--- a/src/Bank3Adapter/Bank3Adapter.csproj
+++ b/src/Bank3Adapter/Bank3Adapter.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="..\.dockerignore">
       <Link>.dockerignore</Link>
     </Content>

--- a/src/Client/Client.csproj
+++ b/src/Client/Client.csproj
@@ -9,6 +9,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+      <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+    </ItemGroup>
+
+    <ItemGroup>
         <Content Include="..\.dockerignore">
           <Link>.dockerignore</Link>
         </Content>

--- a/src/ClientMessages/ClientMessages.csproj
+++ b/src/ClientMessages/ClientMessages.csproj
@@ -7,6 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.0.0" />
     </ItemGroup>
 

--- a/src/CommonConfigurations/CommonConfigurations.csproj
+++ b/src/CommonConfigurations/CommonConfigurations.csproj
@@ -7,6 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+      <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+    </ItemGroup>
+
+    <ItemGroup>
       <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
       <PackageReference Include="NServiceBus" Version="10.1.3" />
       <PackageReference Include="NServiceBus.AmazonSQS" Version="9.0.0" />

--- a/src/EmailSender/EmailSender.csproj
+++ b/src/EmailSender/EmailSender.csproj
@@ -8,6 +8,11 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 
+  <ItemGroup>
+    <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+  </ItemGroup>
+
     <ItemGroup>
         <Content Include="..\.dockerignore">
           <Link>.dockerignore</Link>

--- a/src/LoanBroker/LoanBroker.csproj
+++ b/src/LoanBroker/LoanBroker.csproj
@@ -8,6 +8,11 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 
+  <ItemGroup>
+    <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+  </ItemGroup>
+
     <ItemGroup>
         <Content Include="..\.dockerignore">
           <Link>.dockerignore</Link>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -15,6 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- OpenTelemetry.Exporter.Jaeger 1.6.0-rc.1 (and all previous versions too) moderate vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-38h3-2333-qx47" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="4.5.1" />


### PR DESCRIPTION
There is no fix, for now.