### PR TITLE
Remove OpenTelemetry.Exporter.Jaeger

### DIFF
--- a/src/CommonConfigurations/CommonConfigurations.csproj
+++ b/src/CommonConfigurations/CommonConfigurations.csproj
@@ -17,7 +17,6 @@
       <PackageReference Include="NServiceBus.SagaAudit" Version="6.0.0" />
       <PackageReference Include="OpenTelemetry" Version="1.15.2" />
       <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
-      <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.6.0-rc.1" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
       <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.8.0-rc.1" />
       <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />


### PR DESCRIPTION
It looks like the OpenTelemetry.Exporter.Jaeger was a leftover and it's no longer required